### PR TITLE
[NONPR-1718] update bootstrap-backend-play-27 to 5.3.0

### DIFF
--- a/app/uk/gov/hmrc/nrs/retrieval/config/HttpHead.scala
+++ b/app/uk/gov/hmrc/nrs/retrieval/config/HttpHead.scala
@@ -16,9 +16,8 @@
 
 package uk.gov.hmrc.nrs.retrieval.config
 
-import java.net.URLEncoder
-
 import play.api.Logger
+import play.api.http.Status.NOT_FOUND
 import play.api.libs.json.JsArray
 import uk.gov.hmrc.http.HttpVerbs.{HEAD => HEAD_VERB}
 import uk.gov.hmrc.http._
@@ -26,10 +25,12 @@ import uk.gov.hmrc.http.hooks.HttpHooks
 import uk.gov.hmrc.http.logging.ConnectionTracing
 import uk.gov.hmrc.play.http.ws.{WSHttpResponse, WSRequest}
 
+import java.net.{URL, URLEncoder}
 import scala.concurrent.{ExecutionContext, Future}
 
 trait HeadHttpTransport {
-  def doHead(url: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse]
+  def doHead(url: String, headers: Seq[(String, String)])
+            (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse]
 }
 
 trait CoreHttpReads[+O] {
@@ -42,15 +43,17 @@ object CoreHttpReads extends HttpErrorFunctions {
 
   def responseHandler(method: String, url: String, response: HttpResponse): HttpResponse = {
     response.status match {
-      case status if (status == 404) => {
+      case status if status == NOT_FOUND =>
         logger.info(s"Submission bundle not found $status for query $method $url")
         if(method == HEAD_VERB) {
           response
         } else {
-          HttpResponse(404, JsArray.empty, Map[String,Seq[String]]())
+          HttpResponse(NOT_FOUND, JsArray.empty, Map[String,Seq[String]]())
         }
+      case _ => handleResponseEither(method, url)(response) match {
+        case Right(response) => response
+        case Left(err) => throw err
       }
-      case _ => handleResponse(method, url)(response)
     }
   }
 
@@ -58,30 +61,29 @@ object CoreHttpReads extends HttpErrorFunctions {
 }
 
 trait CoreHead {
-  def HEAD[A](url: String)(implicit rds: CoreHttpReads[A], hc: HeaderCarrier, ec: ExecutionContext): Future[A]
+  def HEAD[A](url: String, headers: Seq[(String, String)])(implicit rds: CoreHttpReads[A], hc: HeaderCarrier, ec: ExecutionContext): Future[A]
 
-  def HEAD[A](url: String, queryParams: Seq[(String, String)])(implicit rds: CoreHttpReads[A], hc: HeaderCarrier, ec: ExecutionContext): Future[A]
+  def HEAD[A](url: String, queryParams: Seq[(String, String)], headers: Seq[(String, String)])(implicit rds: CoreHttpReads[A], hc: HeaderCarrier, ec: ExecutionContext): Future[A]
 }
 
 trait WSHead extends WSRequest with CoreHead with HeadHttpTransport {
 
-  override def doHead(url: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
-    buildRequest(url).head().map(WSHttpResponse(_))
-  }
-
+  override def doHead(url: String, headers: Seq[(String, String)])
+                     (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] =
+    buildRequest(url, headers).head().map(WSHttpResponse(_))
 }
 
 trait HttpHead extends CoreHead with HeadHttpTransport with HttpVerb with ConnectionTracing with HttpHooks {
 
-  override def HEAD[A](url: String)(implicit rds: CoreHttpReads[A], hc: HeaderCarrier, ec: ExecutionContext): Future[A] =
+  override def HEAD[A](url: String, headers: Seq[(String, String)])(implicit rds: CoreHttpReads[A], hc: HeaderCarrier, ec: ExecutionContext): Future[A] =
     withTracing(HEAD_VERB, url) {
 
-      val httpResponse = doHead(url)
-      executeHooks(url, HEAD_VERB, None, httpResponse)
+      val httpResponse = doHead(url, headers)
+      executeHooks(HEAD_VERB, new URL(url), headers, None, httpResponse)
       mapErrors(HEAD_VERB, url, httpResponse).map(response => rds.read(HEAD_VERB, url, response))
     }
 
-  override def HEAD[A](url: String, queryParams: Seq[(String, String)])(
+  override def HEAD[A](url: String, queryParams: Seq[(String, String)], headers: Seq[(String, String)])(
     implicit rds: CoreHttpReads[A],
     hc: HeaderCarrier,
     ec: ExecutionContext): Future[A] = {
@@ -92,7 +94,7 @@ trait HttpHead extends CoreHead with HeadHttpTransport with HttpVerb with Connec
         s"${this.getClass}.HEAD(url, queryParams)",
         "Query parameters must be provided as a Seq of tuples to this method")
     }
-    HEAD(url + queryString)
+    HEAD(url + queryString, headers)
   }
 
   private def makeQueryString(queryParams: Seq[(String, String)]) = {

--- a/app/uk/gov/hmrc/nrs/retrieval/config/WSHttp.scala
+++ b/app/uk/gov/hmrc/nrs/retrieval/config/WSHttp.scala
@@ -35,11 +35,13 @@ package uk.gov.hmrc.nrs.retrieval.config
 import akka.actor.ActorSystem
 import com.google.inject.ImplementedBy
 import com.typesafe.config.Config
-import javax.inject.{Inject, Singleton}
 import play.api.libs.ws.WSClient
 import play.api.{Configuration, Environment}
 import uk.gov.hmrc.http._
+import uk.gov.hmrc.http.hooks.HttpHook
 import uk.gov.hmrc.play.http.ws._
+
+import javax.inject.{Inject, Singleton}
 
 @ImplementedBy(classOf[WSHttp])
 trait WSHttpT extends HttpGet with WSGet
@@ -53,9 +55,7 @@ trait WSHttpT extends HttpGet with WSGet
 class WSHttp @Inject()(val environment: Environment, val runModeConfig: Configuration, val appNameConfig: Configuration, val wsClient: WSClient)
                       (implicit val actorSystem: ActorSystem) extends WSHttpT {
 
-  override val hooks = NoneRequired
+  override val hooks: Seq[HttpHook] = NoneRequired
 
-  // todo : unclear what we need to do with the config here
-  override protected def configuration: Option[Config] = None
-
+  override protected def configuration: Config = runModeConfig.underlying
 }

--- a/app/uk/gov/hmrc/nrs/retrieval/connectors/NonrepRetrievalConnector.scala
+++ b/app/uk/gov/hmrc/nrs/retrieval/connectors/NonrepRetrievalConnector.scala
@@ -32,12 +32,13 @@ package uk.gov.hmrc.nrs.retrieval.connectors
  * limitations under the License.
  */
 
-import javax.inject.{Inject, Singleton}
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.{Environment, Logger}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, HttpResponse}
-import uk.gov.hmrc.nrs.retrieval.config.{AppConfig, WSHttpT}
 import uk.gov.hmrc.nrs.retrieval.config.CoreHttpReads.responseHandler
+import uk.gov.hmrc.nrs.retrieval.config.{AppConfig, WSHttpT}
+
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
@@ -70,13 +71,13 @@ class NonrepRetrievalConnector @Inject()(val environment: Environment,
   def statusSubmissionBundle(vaultId: String, archiveId: String)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
     val path = s"${appConfig.nonrepRetrievalUrl}/retrieval/submission-bundles/$vaultId/$archiveId"
     logger.info(s"Head $path")
-    http.HEAD(path)
+    http.HEAD(path, hc.extraHeaders)
   }
 
   def getSubmissionBundle(vaultId: String, archiveId: String)(implicit hc: HeaderCarrier): Future[WSResponse] = {
     val path = s"${appConfig.nonrepRetrievalUrl}/retrieval/submission-bundles/$vaultId/$archiveId"
     logger.info(s"Get $path")
-    ws.url(path).withHttpHeaders(hc.headers ++ hc.extraHeaders ++ hc.otherHeaders: _*).get
+    ws.url(path).withHttpHeaders(hc.extraHeaders: _*).get
   }
 
   def submissionPing()(implicit hc: HeaderCarrier): Future[HttpResponse] = {

--- a/app/uk/gov/hmrc/nrs/retrieval/connectors/NonrepRetrievalConnector.scala
+++ b/app/uk/gov/hmrc/nrs/retrieval/connectors/NonrepRetrievalConnector.scala
@@ -34,6 +34,7 @@ package uk.gov.hmrc.nrs.retrieval.connectors
 
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.{Environment, Logger}
+import uk.gov.hmrc.http.HeaderNames.explicitlyIncludedHeaders
 import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, HttpResponse}
 import uk.gov.hmrc.nrs.retrieval.config.CoreHttpReads.responseHandler
 import uk.gov.hmrc.nrs.retrieval.config.{AppConfig, WSHttpT}
@@ -71,13 +72,13 @@ class NonrepRetrievalConnector @Inject()(val environment: Environment,
   def statusSubmissionBundle(vaultId: String, archiveId: String)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
     val path = s"${appConfig.nonrepRetrievalUrl}/retrieval/submission-bundles/$vaultId/$archiveId"
     logger.info(s"Head $path")
-    http.HEAD(path, hc.extraHeaders)
+    http.HEAD(path, allHeaders)
   }
 
   def getSubmissionBundle(vaultId: String, archiveId: String)(implicit hc: HeaderCarrier): Future[WSResponse] = {
     val path = s"${appConfig.nonrepRetrievalUrl}/retrieval/submission-bundles/$vaultId/$archiveId"
     logger.info(s"Get $path")
-    ws.url(path).withHttpHeaders(hc.extraHeaders: _*).get
+    ws.url(path).withHttpHeaders(allHeaders: _*).get
   }
 
   def submissionPing()(implicit hc: HeaderCarrier): Future[HttpResponse] = {
@@ -92,4 +93,6 @@ class NonrepRetrievalConnector @Inject()(val environment: Environment,
     http.GET[HttpResponse](path)
   }
 
+  private def allHeaders(implicit hc: HeaderCarrier) =
+    hc.headers(explicitlyIncludedHeaders) ++ hc.extraHeaders ++ hc.otherHeaders
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import play.core.PlayVersion
+import uk.gov.hmrc.DefaultBuildSettings.{defaultSettings, integrationTestSettings}
 import uk.gov.hmrc.SbtAutoBuildPlugin
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin._
 
@@ -16,15 +17,24 @@ lazy val scoverageSettings = {
 
 lazy val compile = Seq(
   ws,
-  "uk.gov.hmrc" %% "bootstrap-backend-play-27" % "3.4.0",
-  "uk.gov.hmrc" %% "simple-reactivemongo" % "7.30.0-play-27"
+  "uk.gov.hmrc" %% "bootstrap-backend-play-27" % "5.3.0",
+  "uk.gov.hmrc" %% "simple-reactivemongo" % "8.0.0-play-27"
 )
 
-def test(scope: String) = Seq(
-  "uk.gov.hmrc" %% "hmrctest" % "3.10.0-play-26" % scope,
-  "org.scalatest" %% "scalatest" % "3.0.8" % scope,
-  "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
-  "org.mockito" % "mockito-all" % "2.0.2-beta" % scope
+lazy val test = Seq(
+  "uk.gov.hmrc" %% "hmrctest" % "3.10.0-play-26" % "test",
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test",
+  "com.typesafe.play" %% "play-test" % PlayVersion.current % "test",
+  "org.mockito" % "mockito-all" % "2.0.2-beta" % "test"
+)
+
+lazy val itTest = Seq(
+  "uk.gov.hmrc" %% "hmrctest" % "3.10.0-play-26" % "it",
+  "org.scalatest" %% "scalatest" % "3.0.8" % "it",
+  "com.typesafe.play" %% "play-test" % PlayVersion.current % "it",
+  "org.mockito" % "mockito-all" % "2.0.2-beta" % "it",
+  "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % "it",
+  "com.github.tomakehurst" % "wiremock-jre8" % "2.21.0" % "it"
 )
 
 lazy val appName: String = "nrs-retrieval"
@@ -41,7 +51,7 @@ lazy val root = (project in file("."))
     resolvers ++= Seq(
       Resolver.typesafeRepo("releases")
     ),
-    libraryDependencies ++=  compile ++ test("test") ++ test("it"),
+    libraryDependencies ++=  compile ++ test ++ itTest,
     libraryDependencies ++= Seq(
       compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full),
       "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.full
@@ -49,6 +59,8 @@ lazy val root = (project in file("."))
     scalacOptions += "-P:silencer:pathFilters=target/.*",
     publishingSettings,
     scoverageSettings)
+  .settings(defaultSettings(): _*)
+  .settings(integrationTestSettings())
   .configs(IntegrationTest)
   .settings(
     Keys.fork in IntegrationTest := false,
@@ -58,5 +70,3 @@ lazy val root = (project in file("."))
   )
   .enablePlugins(PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory)
   .disablePlugins(JUnitXmlReportPlugin)
-
-inConfig(IntegrationTest)(Defaults.itSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -31,8 +31,6 @@ lazy val test = Seq(
 lazy val itTest = Seq(
   "uk.gov.hmrc" %% "hmrctest" % "3.10.0-play-26" % "it",
   "org.scalatest" %% "scalatest" % "3.0.8" % "it",
-  "com.typesafe.play" %% "play-test" % PlayVersion.current % "it",
-  "org.mockito" % "mockito-all" % "2.0.2-beta" % "it",
   "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % "it",
   "com.github.tomakehurst" % "wiremock-jre8" % "2.21.0" % "it"
 )

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -5,5 +5,5 @@ POST       /submission-bundles/:vaultId/:archiveId/retrieval-requests    @uk.gov
 HEAD       /submission-bundles/:vaultId/:archiveId                       @uk.gov.hmrc.nrs.retrieval.controllers.NonrepRetrievalController.statusSubmissionBundle(vaultId, archiveId)
 GET        /submission-bundles/:vaultId/:archiveId                       @uk.gov.hmrc.nrs.retrieval.controllers.NonrepRetrievalController.getSubmissionBundle(vaultId, archiveId)
 
-GET         /submission/ping                  @uk.gov.hmrc.nrs.retrieval.controllers.NonrepRetrievalController.submissionPing
-GET         /retrieval/ping                   @uk.gov.hmrc.nrs.retrieval.controllers.NonrepRetrievalController.retrievalPing
+GET        /submission/ping                                              @uk.gov.hmrc.nrs.retrieval.controllers.NonrepRetrievalController.submissionPing
+GET        /retrieval/ping                                               @uk.gov.hmrc.nrs.retrieval.controllers.NonrepRetrievalController.retrievalPing

--- a/it/uk/gov/hmrc/DELETEME
+++ b/it/uk/gov/hmrc/DELETEME
@@ -1,1 +1,0 @@
-file just here to enable commit of the directories

--- a/it/uk/gov/hmrc/nrs/retrieval/NrsRetrievalIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/nrs/retrieval/NrsRetrievalIntegrationSpec.scala
@@ -1,0 +1,231 @@
+package uk.gov.hmrc.nrs.retrieval
+
+import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, head, post, urlPathMatching}
+import com.github.tomakehurst.wiremock.client.{MappingBuilder, WireMock}
+import com.github.tomakehurst.wiremock.matching.EqualToPattern
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpecLike}
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.ws.WSClient
+
+class NrsRetrievalIntegrationSpec
+  extends WordSpecLike
+    with Matchers
+    with ScalaFutures
+    with GuiceOneServerPerSuite
+    with WireMockSupport
+    with IntegrationPatience
+    with BeforeAndAfterEach {
+  private val xApiKeyHeader = "X-API-Key"
+  private val xApiKey = "xApiKey"
+  private val equalsXApiKey = new EqualToPattern(xApiKey)
+
+  override lazy val port: Int = 19391
+
+  private lazy val local = s"http://localhost:$port"
+  private lazy val serviceRoot = s"$local/nrs-retrieval"
+
+  /*
+   * Use WSClient rather than HttpClient here because:
+   * 1. we have implemented our own HttpClient.HEAD (with opinionated behaviour) and we don't want to mix tests of
+   *    this with tests of service endpoint behaviour.
+   * 2. when we update http-verbs the tests are not subtly changed.
+   */
+  private lazy val wsClient = fakeApplication().injector.instanceOf[WSClient]
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder().configure(Map[String, Any](
+      "awsservices.nonrepSubmissionPing.url" -> wireMockBaseUrl,
+      "awsservices.nonrepRetrievalPing.url" -> wireMockBaseUrl,
+      "awsservices.nonrepRetrieval.url" -> wireMockBaseUrl,
+      "auditing.enabled" -> false,
+      "metrics.jvm" -> false)
+    ).build()
+
+  override def beforeEach(): Unit = WireMock.reset()
+
+  private def wsClientWithXApiKeyHeader(url: String) =
+    wsClient.url(url).withHttpHeaders((xApiKeyHeader, xApiKey))
+
+  private def mappingBuilder(headMapping: MappingBuilder, withHeaders: Boolean) =
+    if (withHeaders) {
+      headMapping.withHeader(xApiKeyHeader, equalsXApiKey)
+    } else {
+      headMapping
+    }
+
+  "GET /ping/ping" should {
+    "succeed" in {
+      wsClient.url(s"$local/ping/ping").get().futureValue.status shouldBe OK
+    }
+  }
+
+  "GET /nrs-retrieval/submission/ping" should {
+    "succeed" in {
+      wsClient.url(s"$serviceRoot/submission/ping").get().futureValue.status shouldBe OK
+    }
+  }
+
+  "GET /nrs-retrieval/retrieval/ping" should {
+    "succeed" in {
+      wsClient.url(s"$serviceRoot/retrieval/ping").get().futureValue.status shouldBe OK
+    }
+  }
+
+  "GET /nrs-retrieval/submission-metadata" should {
+    "succeed" in {
+      wsClient.url(s"$serviceRoot/submission-metadata").get().futureValue.status shouldBe OK
+    }
+  }
+
+  "GET /nrs-retrieval/submission-bundles/:vaultId/:archiveId" should {
+    "succeed" in {
+      wsClient.url(s"$serviceRoot/submission-bundles/vaultId/archiveId").get().futureValue.status shouldBe OK
+    }
+  }
+
+  "HEAD /nrs-retrieval/submission-bundles/:vaultId/:archiveId" should {
+    val url = s"$serviceRoot/submission-bundles/vaultId/archiveId"
+    val requestWithoutHeaders = wsClient.url(url)
+    val requestWithHeader = wsClientWithXApiKeyHeader(url)
+
+    def givenSubmissionBundlesReturns(status: Int, withHeaders: Boolean): Unit =
+      wireMockServer.addStubMapping(
+        mappingBuilder(
+          head(urlPathMatching("/retrieval/submission-bundles/vaultId/archiveId")), withHeaders
+        ).willReturn(aResponse().withStatus(status)).build())
+
+    Seq(
+      (requestWithHeader, true, "the X-API-Key header"),
+      (requestWithoutHeaders, false, "no headers")
+    ).foreach{ case (request, withHeaders, headersLabel) =>
+      "pass through the X-API-Key header if set and return OK" when {
+        s"the request has $headersLabel and the submission bundles request returns OK" in {
+          givenSubmissionBundlesReturns(OK, withHeaders)
+          request.head().futureValue.status shouldBe OK
+        }
+
+       s"the request has $headersLabel and the submission bundles request returns a 2xx status" in {
+          givenSubmissionBundlesReturns(CREATED, withHeaders)
+          request.head().futureValue.status shouldBe OK
+        }
+      }
+
+      "pass through the X-API-Key header if set and return ACCEPTED" when {
+        s"the request has $headersLabel and the submission bundles request returns ACCEPTED" in {
+          givenSubmissionBundlesReturns(ACCEPTED, withHeaders)
+          request.head().futureValue.status shouldBe ACCEPTED
+        }
+      }
+
+      "pass through the X-API-Key header if set and return BAD_REQUEST" when {
+        s"the request has $headersLabel and the submission bundles request returns BAD_REQUEST" in {
+          givenSubmissionBundlesReturns(BAD_REQUEST, withHeaders)
+          request.head().futureValue.status shouldBe BAD_REQUEST
+        }
+      }
+
+      "pass through the X-API-Key header if set and return NOT_FOUND" when {
+        s"the request has $headersLabel and the submit request returns NOT_FOUND" in {
+          givenSubmissionBundlesReturns(NOT_FOUND, withHeaders)
+          request.head().futureValue.status shouldBe NOT_FOUND
+        }
+      }
+
+      "pass through the X-API-Key header if set and return INTERNAL_SERVER_ERROR" when {
+        s"the request has $headersLabel and the submit request returns a 3xx status" in {
+          givenSubmissionBundlesReturns(SEE_OTHER, withHeaders)
+          request.head().futureValue.status shouldBe INTERNAL_SERVER_ERROR
+        }
+
+        Seq(UNAUTHORIZED, FORBIDDEN).foreach{ status =>
+          s"the request has $headersLabel and the submit request returns a 4xx status $status" in {
+            givenSubmissionBundlesReturns(status, withHeaders)
+            request.head().futureValue.status shouldBe INTERNAL_SERVER_ERROR
+          }
+        }
+      }
+
+      "pass through the X-API-Key header if set and return BAD_GATEWAY" when {
+        s"the request has $headersLabel and the submit request returns a 5xx status" in {
+          givenSubmissionBundlesReturns(INTERNAL_SERVER_ERROR, withHeaders)
+          request.head().futureValue.status shouldBe BAD_GATEWAY
+        }
+      }
+    }
+  }
+
+  "POST /nrs-retrieval/submission-bundles/:vaultId/:archiveId/retrieval-requests" should {
+    val requestBody = ""
+    val url = s"$serviceRoot/submission-bundles/vaultId/archiveId/retrieval-requests"
+    val requestWithoutHeaders = wsClient.url(url)
+    val requestWithHeader = wsClientWithXApiKeyHeader(url)
+
+    def givenSubmitRetrievalRequestReturns(status: Int, withHeaders: Boolean): Unit =
+      wireMockServer.addStubMapping(
+        mappingBuilder(
+          post(urlPathMatching("/retrieval/submission-bundles/vaultId/archiveId/retrieval-requests")), withHeaders
+        ).willReturn(aResponse().withStatus(status)).build())
+
+    Seq(
+      (requestWithHeader, true, "the X-API-Key header"),
+      (requestWithoutHeaders, false, "no headers")
+    ).foreach { case (request, withHeaders, headersLabel) =>
+      "pass through the X-API-Key header if set and return OK " when {
+        s"the request has $headersLabel and the submit request returns OK" in {
+          givenSubmitRetrievalRequestReturns(OK, withHeaders)
+          request.post(requestBody).futureValue.status shouldBe OK
+        }
+
+        s"the request has $headersLabel and the submit request returns a 2xx status" in {
+          givenSubmitRetrievalRequestReturns(CREATED, withHeaders)
+          request.post(requestBody).futureValue.status shouldBe OK
+        }
+      }
+
+      "pass through the X-API-Key header if set and return ACCEPTED" when {
+        s"the request has $headersLabel and the submit request returns ACCEPTED" in {
+          givenSubmitRetrievalRequestReturns(ACCEPTED, withHeaders)
+          requestWithHeader.post(requestBody).futureValue.status shouldBe ACCEPTED
+        }
+      }
+
+      "pass through the X-API-Key header if set and return BAD_REQUEST" when {
+        s"the request has $headersLabel and the submit request returns BAD_REQUEST" in {
+          givenSubmitRetrievalRequestReturns(BAD_REQUEST, withHeaders)
+          requestWithHeader.post(requestBody).futureValue.status shouldBe BAD_REQUEST
+        }
+      }
+
+      "pass through the X-API-Key header if set and return NOT_FOUND" when {
+        s"the request has $headersLabel and the submit request returns NOT_FOUND" in {
+          givenSubmitRetrievalRequestReturns(NOT_FOUND, withHeaders)
+          requestWithHeader.post(requestBody).futureValue.status shouldBe NOT_FOUND
+        }
+      }
+
+      "pass through the X-API-Key header if set and return INTERNAL_SERVER_ERROR" when {
+        s"the request has $headersLabel and the submit request returns a 3xx status" in {
+          givenSubmitRetrievalRequestReturns(SEE_OTHER, withHeaders)
+          requestWithHeader.post(requestBody).futureValue.status shouldBe INTERNAL_SERVER_ERROR
+        }
+
+        Seq(UNAUTHORIZED, FORBIDDEN).foreach { status =>
+          s"the request has $headersLabel and the submit request returns a 4xx status $status" in {
+            givenSubmitRetrievalRequestReturns(status, withHeaders)
+            requestWithHeader.post(requestBody).futureValue.status shouldBe INTERNAL_SERVER_ERROR
+          }
+        }
+      }
+
+      "pass through the X-API-Key header if set and return BAD_GATEWAY" when {
+        s"the request has $headersLabel and the submit request returns a 5xx status" in {
+          givenSubmitRetrievalRequestReturns(INTERNAL_SERVER_ERROR, withHeaders)
+          requestWithHeader.post(requestBody).futureValue.status shouldBe BAD_GATEWAY
+        }
+      }
+    }
+  }
+}

--- a/it/uk/gov/hmrc/nrs/retrieval/NrsRetrievalIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/nrs/retrieval/NrsRetrievalIntegrationSpec.scala
@@ -120,13 +120,6 @@ class NrsRetrievalIntegrationSpec
         }
       }
 
-      "pass through the X-API-Key header if set and return BAD_REQUEST" when {
-        s"the request has $headersLabel and the submission bundles request returns BAD_REQUEST" in {
-          givenSubmissionBundlesReturns(BAD_REQUEST, withHeaders)
-          request.head().futureValue.status shouldBe BAD_REQUEST
-        }
-      }
-
       "pass through the X-API-Key header if set and return NOT_FOUND" when {
         s"the request has $headersLabel and the submit request returns NOT_FOUND" in {
           givenSubmissionBundlesReturns(NOT_FOUND, withHeaders)
@@ -140,7 +133,7 @@ class NrsRetrievalIntegrationSpec
           request.head().futureValue.status shouldBe INTERNAL_SERVER_ERROR
         }
 
-        Seq(UNAUTHORIZED, FORBIDDEN).foreach{ status =>
+        Seq(BAD_REQUEST, UNAUTHORIZED, FORBIDDEN).foreach{ status =>
           s"the request has $headersLabel and the submit request returns a 4xx status $status" in {
             givenSubmissionBundlesReturns(status, withHeaders)
             request.head().futureValue.status shouldBe INTERNAL_SERVER_ERROR
@@ -192,13 +185,6 @@ class NrsRetrievalIntegrationSpec
         }
       }
 
-      "pass through the X-API-Key header if set and return BAD_REQUEST" when {
-        s"the request has $headersLabel and the submit request returns BAD_REQUEST" in {
-          givenSubmitRetrievalRequestReturns(BAD_REQUEST, withHeaders)
-          requestWithHeader.post(requestBody).futureValue.status shouldBe BAD_REQUEST
-        }
-      }
-
       "pass through the X-API-Key header if set and return NOT_FOUND" when {
         s"the request has $headersLabel and the submit request returns NOT_FOUND" in {
           givenSubmitRetrievalRequestReturns(NOT_FOUND, withHeaders)
@@ -212,7 +198,7 @@ class NrsRetrievalIntegrationSpec
           requestWithHeader.post(requestBody).futureValue.status shouldBe INTERNAL_SERVER_ERROR
         }
 
-        Seq(UNAUTHORIZED, FORBIDDEN).foreach { status =>
+        Seq(BAD_REQUEST, UNAUTHORIZED, FORBIDDEN).foreach { status =>
           s"the request has $headersLabel and the submit request returns a 4xx status $status" in {
             givenSubmitRetrievalRequestReturns(status, withHeaders)
             requestWithHeader.post(requestBody).futureValue.status shouldBe INTERNAL_SERVER_ERROR

--- a/it/uk/gov/hmrc/nrs/retrieval/NrsRetrievalIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/nrs/retrieval/NrsRetrievalIntegrationSpec.scala
@@ -1,6 +1,6 @@
 package uk.gov.hmrc.nrs.retrieval
 
-import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, head, post, urlPathMatching}
+import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.client.{MappingBuilder, WireMock}
 import com.github.tomakehurst.wiremock.matching.EqualToPattern
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
@@ -56,6 +56,19 @@ class NrsRetrievalIntegrationSpec
       headMapping
     }
 
+  private def givenRequestRedirects(builder: MappingBuilder, withHeaders: Boolean): Unit = {
+    val redirectPath = "/redirect"
+    val redirectUrl = s"$wireMockBaseUrl$redirectPath"
+
+    wireMockServer.addStubMapping(
+      mappingBuilder(get(urlPathMatching(redirectPath)), withHeaders).willReturn(aResponse().withStatus(OK))
+        .build())
+
+    wireMockServer.addStubMapping(
+      mappingBuilder( builder, withHeaders).willReturn(aResponse().withStatus(SEE_OTHER).withHeader("Location", redirectUrl )).build())
+  }
+
+
   "GET /ping/ping" should {
     "succeed" in {
       wsClient.url(s"$local/ping/ping").get().futureValue.status shouldBe OK
@@ -63,26 +76,177 @@ class NrsRetrievalIntegrationSpec
   }
 
   "GET /nrs-retrieval/submission/ping" should {
-    "succeed" in {
-      wsClient.url(s"$serviceRoot/submission/ping").get().futureValue.status shouldBe OK
+    val url = s"$serviceRoot/submission/ping"
+    val requestWithoutHeaders = wsClient.url(url)
+    val requestWithHeader = wsClientWithXApiKeyHeader(url)
+    val retrievalPath = "/submission/ping"
+
+    def givenSubmissionPingReturns(status: Int, withHeaders: Boolean): Unit =
+      wireMockServer.addStubMapping(
+        mappingBuilder(get(urlPathMatching(retrievalPath)), withHeaders)
+          .willReturn(aResponse().withStatus(status)).build())
+
+    Seq(
+      (requestWithHeader, true, "the X-API-Key header"),
+      (requestWithoutHeaders, false, "no headers")
+    ).foreach { case (request, withHeaders, headersLabel) =>
+      "pass through the X-API-Key header if set and return OK" when {
+        Seq(OK, CREATED, ACCEPTED, NOT_FOUND).foreach { status =>
+          s"the request has $headersLabel and the submission bundles request returns the status $status" in {
+            givenSubmissionPingReturns(status, withHeaders)
+            request.get().futureValue.status shouldBe OK
+          }
+        }
+
+        s"the request has $headersLabel and the submit request returns a 3xx status" in {
+          givenRequestRedirects(get(urlPathMatching(retrievalPath)), withHeaders)
+          request.get().futureValue.status shouldBe OK
+        }
+      }
+
+      "pass through the X-API-Key header if set and return INTERNAL_SERVER_ERROR" when {
+        Seq(BAD_REQUEST, UNAUTHORIZED, FORBIDDEN).foreach { status =>
+          s"the request has $headersLabel and the submit request returns a 4xx status $status" in {
+            givenSubmissionPingReturns(status, withHeaders)
+            request.get().futureValue.status shouldBe INTERNAL_SERVER_ERROR
+          }
+        }
+      }
+
+      "pass through the X-API-Key header if set and return BAD_GATEWAY" when {
+        s"the request has $headersLabel and the submit request returns a 5xx status" in {
+          givenSubmissionPingReturns(INTERNAL_SERVER_ERROR, withHeaders)
+          request.get().futureValue.status shouldBe BAD_GATEWAY
+        }
+      }
     }
   }
 
   "GET /nrs-retrieval/retrieval/ping" should {
-    "succeed" in {
-      wsClient.url(s"$serviceRoot/retrieval/ping").get().futureValue.status shouldBe OK
+    val url = s"$serviceRoot/retrieval/ping"
+    val requestWithoutHeaders = wsClient.url(url)
+    val requestWithHeader = wsClientWithXApiKeyHeader(url)
+    val retrievalPath = "/retrieval/ping"
+
+    def givenRetrievalPingReturns(status: Int, withHeaders: Boolean): Unit =
+      wireMockServer.addStubMapping(
+        mappingBuilder(get(urlPathMatching(retrievalPath)), withHeaders)
+          .willReturn(aResponse().withStatus(status)).build())
+
+    Seq(
+      (requestWithHeader, true, "the X-API-Key header"),
+      (requestWithoutHeaders, false, "no headers")
+    ).foreach { case (request, withHeaders, headersLabel) =>
+      "pass through the X-API-Key header if set and return OK" when {
+        Seq(OK, CREATED, ACCEPTED, NOT_FOUND).foreach { status =>
+          s"the request has $headersLabel and the submission bundles request returns the status $status" in {
+            givenRetrievalPingReturns(status, withHeaders)
+            request.get().futureValue.status shouldBe OK
+          }
+        }
+
+        s"the request has $headersLabel and the submit request returns a 3xx status" in {
+          givenRequestRedirects(get(urlPathMatching(retrievalPath)), withHeaders)
+          request.get().futureValue.status shouldBe OK
+        }
+      }
+
+      "pass through the X-API-Key header if set and return INTERNAL_SERVER_ERROR" when {
+        Seq(BAD_REQUEST, UNAUTHORIZED, FORBIDDEN).foreach { status =>
+          s"the request has $headersLabel and the submit request returns a 4xx status $status" in {
+            givenRetrievalPingReturns(status, withHeaders)
+            request.get().futureValue.status shouldBe INTERNAL_SERVER_ERROR
+          }
+        }
+      }
+
+      "pass through the X-API-Key header if set and return BAD_GATEWAY" when {
+        s"the request has $headersLabel and the submit request returns a 5xx status" in {
+          givenRetrievalPingReturns(INTERNAL_SERVER_ERROR, withHeaders)
+          request.get().futureValue.status shouldBe BAD_GATEWAY
+        }
+      }
     }
+
   }
 
   "GET /nrs-retrieval/submission-metadata" should {
-    "succeed" in {
-      wsClient.url(s"$serviceRoot/submission-metadata").get().futureValue.status shouldBe OK
+    val url = s"$serviceRoot/submission-metadata"
+    val requestWithoutHeaders = wsClient.url(url)
+    val requestWithHeader = wsClientWithXApiKeyHeader(url)
+    val retrievalPath = "/retrieval/submission-metadata"
+
+    def givenSubmissionMetaDataReturns(status: Int, withHeaders: Boolean): Unit =
+      wireMockServer.addStubMapping(
+        mappingBuilder(get(urlPathMatching(retrievalPath)), withHeaders)
+          .willReturn(aResponse().withStatus(status)).build())
+
+    Seq(
+      (requestWithHeader, true, "the X-API-Key header"),
+      (requestWithoutHeaders, false, "no headers")
+    ).foreach { case (request, withHeaders, headersLabel) =>
+      "pass through the X-API-Key header if set and return OK" when {
+        Seq(OK, CREATED, ACCEPTED, NOT_FOUND).foreach { status =>
+          s"the request has $headersLabel and the submission bundles request returns the status $status" in {
+            givenSubmissionMetaDataReturns(status, withHeaders)
+            request.get().futureValue.status shouldBe OK
+          }
+        }
+
+        s"the request has $headersLabel and the submit request returns a 3xx status" in {
+          givenRequestRedirects(get(urlPathMatching(retrievalPath)), withHeaders)
+          request.get().futureValue.status shouldBe OK
+        }
+      }
+
+      "pass through the X-API-Key header if set and return INTERNAL_SERVER_ERROR" when {
+        Seq(BAD_REQUEST, UNAUTHORIZED, FORBIDDEN).foreach { status =>
+          s"the request has $headersLabel and the submit request returns a 4xx status $status" in {
+            givenSubmissionMetaDataReturns(status, withHeaders)
+            request.get().futureValue.status shouldBe INTERNAL_SERVER_ERROR
+          }
+        }
+      }
+
+      "pass through the X-API-Key header if set and return BAD_GATEWAY" when {
+        s"the request has $headersLabel and the submit request returns a 5xx status" in {
+          givenSubmissionMetaDataReturns(INTERNAL_SERVER_ERROR, withHeaders)
+          request.get().futureValue.status shouldBe BAD_GATEWAY
+        }
+      }
     }
   }
 
   "GET /nrs-retrieval/submission-bundles/:vaultId/:archiveId" should {
-    "succeed" in {
-      wsClient.url(s"$serviceRoot/submission-bundles/vaultId/archiveId").get().futureValue.status shouldBe OK
+    val url = s"$serviceRoot/submission-bundles/vaultId/archiveId"
+    val requestWithoutHeaders = wsClient.url(url)
+    val requestWithHeader = wsClientWithXApiKeyHeader(url)
+    val retrievalPath = "/retrieval/submission-bundles/vaultId/archiveId"
+
+    def givenSubmissionBundlesReturns(status: Int, withHeaders: Boolean): Unit =
+      wireMockServer.addStubMapping(
+        mappingBuilder(get(urlPathMatching(retrievalPath)), withHeaders)
+          .willReturn(aResponse().withStatus(status)).build())
+
+    Seq(
+      (requestWithHeader, true, "the X-API-Key header"),
+      (requestWithoutHeaders, false, "no headers")
+    ).foreach { case (request, withHeaders, headersLabel) =>
+      "pass through the X-API-Key header if set and return OK" when {
+        Seq(OK, CREATED, ACCEPTED, BAD_REQUEST, UNAUTHORIZED, FORBIDDEN, NOT_FOUND, INTERNAL_SERVER_ERROR, BAD_GATEWAY).foreach { status =>
+          s"the request has $headersLabel and the submission bundles request returns the status $status" in {
+            givenSubmissionBundlesReturns(status, withHeaders)
+            request.get().futureValue.status shouldBe OK
+            verify(1, getRequestedFor(urlEqualTo(retrievalPath)))
+          }
+        }
+
+        s"the request has $headersLabel and the submit request returns a 3xx status" in {
+          givenRequestRedirects(get(urlPathMatching(retrievalPath)), withHeaders)
+          request.get().futureValue.status shouldBe OK
+          verify(1, getRequestedFor(urlEqualTo(retrievalPath)))
+        }
+      }
     }
   }
 
@@ -90,12 +254,12 @@ class NrsRetrievalIntegrationSpec
     val url = s"$serviceRoot/submission-bundles/vaultId/archiveId"
     val requestWithoutHeaders = wsClient.url(url)
     val requestWithHeader = wsClientWithXApiKeyHeader(url)
+    val retrievalPath = "/retrieval/submission-bundles/vaultId/archiveId"
 
     def givenSubmissionBundlesReturns(status: Int, withHeaders: Boolean): Unit =
       wireMockServer.addStubMapping(
-        mappingBuilder(
-          head(urlPathMatching("/retrieval/submission-bundles/vaultId/archiveId")), withHeaders
-        ).willReturn(aResponse().withStatus(status)).build())
+        mappingBuilder(head(urlPathMatching(retrievalPath)), withHeaders)
+          .willReturn(aResponse().withStatus(status)).build())
 
     Seq(
       (requestWithHeader, true, "the X-API-Key header"),
@@ -109,6 +273,11 @@ class NrsRetrievalIntegrationSpec
 
        s"the request has $headersLabel and the submission bundles request returns a 2xx status" in {
           givenSubmissionBundlesReturns(CREATED, withHeaders)
+          request.head().futureValue.status shouldBe OK
+        }
+
+        s"the request has $headersLabel and the submit request returns a 3xx status" in {
+          givenRequestRedirects(head(urlPathMatching(retrievalPath)), withHeaders)
           request.head().futureValue.status shouldBe OK
         }
       }
@@ -128,11 +297,6 @@ class NrsRetrievalIntegrationSpec
       }
 
       "pass through the X-API-Key header if set and return INTERNAL_SERVER_ERROR" when {
-        s"the request has $headersLabel and the submit request returns a 3xx status" in {
-          givenSubmissionBundlesReturns(SEE_OTHER, withHeaders)
-          request.head().futureValue.status shouldBe INTERNAL_SERVER_ERROR
-        }
-
         Seq(BAD_REQUEST, UNAUTHORIZED, FORBIDDEN).foreach{ status =>
           s"the request has $headersLabel and the submit request returns a 4xx status $status" in {
             givenSubmissionBundlesReturns(status, withHeaders)
@@ -155,12 +319,12 @@ class NrsRetrievalIntegrationSpec
     val url = s"$serviceRoot/submission-bundles/vaultId/archiveId/retrieval-requests"
     val requestWithoutHeaders = wsClient.url(url)
     val requestWithHeader = wsClientWithXApiKeyHeader(url)
+    val retrievalPath = "/retrieval/submission-bundles/vaultId/archiveId/retrieval-requests"
 
     def givenSubmitRetrievalRequestReturns(status: Int, withHeaders: Boolean): Unit =
       wireMockServer.addStubMapping(
-        mappingBuilder(
-          post(urlPathMatching("/retrieval/submission-bundles/vaultId/archiveId/retrieval-requests")), withHeaders
-        ).willReturn(aResponse().withStatus(status)).build())
+        mappingBuilder(post(urlPathMatching(retrievalPath)), withHeaders)
+          .willReturn(aResponse().withStatus(status)).build())
 
     Seq(
       (requestWithHeader, true, "the X-API-Key header"),
@@ -176,32 +340,32 @@ class NrsRetrievalIntegrationSpec
           givenSubmitRetrievalRequestReturns(CREATED, withHeaders)
           request.post(requestBody).futureValue.status shouldBe OK
         }
+
+        s"the request has $headersLabel and the submit request returns a 3xx status" in {
+          givenRequestRedirects(post(urlPathMatching(retrievalPath)), withHeaders)
+          request.post(requestBody).futureValue.status shouldBe OK
+        }
       }
 
       "pass through the X-API-Key header if set and return ACCEPTED" when {
         s"the request has $headersLabel and the submit request returns ACCEPTED" in {
           givenSubmitRetrievalRequestReturns(ACCEPTED, withHeaders)
-          requestWithHeader.post(requestBody).futureValue.status shouldBe ACCEPTED
+          request.post(requestBody).futureValue.status shouldBe ACCEPTED
         }
       }
 
       "pass through the X-API-Key header if set and return NOT_FOUND" when {
         s"the request has $headersLabel and the submit request returns NOT_FOUND" in {
           givenSubmitRetrievalRequestReturns(NOT_FOUND, withHeaders)
-          requestWithHeader.post(requestBody).futureValue.status shouldBe NOT_FOUND
+          request.post(requestBody).futureValue.status shouldBe NOT_FOUND
         }
       }
 
       "pass through the X-API-Key header if set and return INTERNAL_SERVER_ERROR" when {
-        s"the request has $headersLabel and the submit request returns a 3xx status" in {
-          givenSubmitRetrievalRequestReturns(SEE_OTHER, withHeaders)
-          requestWithHeader.post(requestBody).futureValue.status shouldBe INTERNAL_SERVER_ERROR
-        }
-
         Seq(BAD_REQUEST, UNAUTHORIZED, FORBIDDEN).foreach { status =>
           s"the request has $headersLabel and the submit request returns a 4xx status $status" in {
             givenSubmitRetrievalRequestReturns(status, withHeaders)
-            requestWithHeader.post(requestBody).futureValue.status shouldBe INTERNAL_SERVER_ERROR
+            request.post(requestBody).futureValue.status shouldBe INTERNAL_SERVER_ERROR
           }
         }
       }
@@ -209,7 +373,7 @@ class NrsRetrievalIntegrationSpec
       "pass through the X-API-Key header if set and return BAD_GATEWAY" when {
         s"the request has $headersLabel and the submit request returns a 5xx status" in {
           givenSubmitRetrievalRequestReturns(INTERNAL_SERVER_ERROR, withHeaders)
-          requestWithHeader.post(requestBody).futureValue.status shouldBe BAD_GATEWAY
+          request.post(requestBody).futureValue.status shouldBe BAD_GATEWAY
         }
       }
     }

--- a/it/uk/gov/hmrc/nrs/retrieval/WireMockSupport.scala
+++ b/it/uk/gov/hmrc/nrs/retrieval/WireMockSupport.scala
@@ -1,0 +1,28 @@
+package uk.gov.hmrc.nrs.retrieval
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, Suite}
+import play.api.http.Status
+
+trait WireMockSupport extends BeforeAndAfterAll with BeforeAndAfter with Status { self: Suite =>
+  val wireMockHost = "localhost"
+  val wireMockPort = 11111
+  val wireMockBaseUrl = s"http://$wireMockHost:$wireMockPort"
+
+  lazy val wireMockServer = new WireMockServer(wireMockConfig().port(wireMockPort))
+
+  configureFor(wireMockHost, wireMockPort)
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    wireMockServer.start()
+  }
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    wireMockServer.stop()
+  }
+}
+


### PR DESCRIPTION
See https://jira.tools.tax.service.gov.uk/browse/NONPR-1718

Part of this upgrade is to upgrade `http-verbs` to `13.6.0`. This includes changes both to default handling of `400` and `404` responses returned by http client calls. It also includes a change to the way headers are propagated. See  https://github.com/hmrc/http-verbs/blob/master/CHANGELOG.md for more details

It was felt these changes might have some subtle effects on behaviour, and that we should add some integration tests In order to increase confidence. 

These were added against a version without the play upgrade here:
https://github.com/hmrc/nrs-retrieval/tree/NONPR-1718-it-tests

and then merged into this branch also.

I found one subtle change in behaviour. When the httpClient response has status 400 BAD_REQUEST we used to return a 400 (see https://github.com/hmrc/nrs-retrieval/tree/NONPR-1718-it-tests) but post-upgrade we return a 500 INTERNAL_SERVER_ERROR. I don't see any custom handling of 400 BAD_REQUEST in nrs-retrieval-frontend so I suspect this slight change in behaviour is immaterial and does not cause the acceptance tests to fail.

test results:
```
[info] ScalaTest
[info] Run completed in 4 seconds, 278 milliseconds.
[info] Total number of tests run: 8
[info] Suites: completed 2, aborted 0
[info] Tests: succeeded 8, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```


it:test results:
```
[info] Run completed in 15 seconds, 794 milliseconds.
[info] Total number of tests run: 41
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 41, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 41, Failed 0, Errors 0, Passed 41
```

The `nrs-retrieval-acceptance-tests` run against this locally.

```

[info] ScalaTest
[info] Run completed in 3 minutes, 45 seconds.
[info] Total number of tests run: 0
[info] Suites: completed 0, aborted 0
[info] Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
[info] No tests were executed.
[info] Passed: Total 186, Failed 0, Errors 0, Passed 186
[success] Total time: 240 s, completed 28-May-2021 13:45:01
```