### PR TITLE
NONPR-1718 remove unused mongo dependencies

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,47 @@
+style = defaultWithAlign
+maxColumn = 140
+lineEndings = unix
+importSelectors = singleLine
+
+project {
+  git = true
+}
+
+align = none
+
+align {
+  tokens = [ {code = "=>", owner = "Case|Type.Arg.ByName"}, "<-", "->", "%", "%%" ]
+  arrowEnumeratorGenerator = true
+  openParenCallSite = false
+  openParenDefnSite = false
+}
+
+binPack {
+  parentConstructors = true
+}
+
+continuationIndent {
+  callSite = 2
+  defnSite = 2
+}
+
+newlines {
+  penalizeSingleSelectMultiArgList = false
+  sometimesBeforeColonInMethodReturnType = true
+}
+
+rewrite {
+  rules = [RedundantBraces, RedundantParens, AsciiSortImports]
+  redundantBraces {
+    maxLines = 100
+    includeUnitMethods = true
+    stringInterpolation = true
+  }
+}
+
+spaces {
+  inImportCurlyBraces = false
+  beforeContextBoundColon = false
+}
+
+assumeStandardLibraryStripMargin = true

--- a/app/uk/gov/hmrc/nrs/retrieval/config/WSHttp.scala
+++ b/app/uk/gov/hmrc/nrs/retrieval/config/WSHttp.scala
@@ -16,22 +16,6 @@
 
 package uk.gov.hmrc.nrs.retrieval.config
 
-/*
- * Copyright 2018 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import akka.actor.ActorSystem
 import com.google.inject.ImplementedBy
 import com.typesafe.config.Config

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import play.core.PlayVersion
+import play.core.PlayVersion.current
 import uk.gov.hmrc.DefaultBuildSettings.{defaultSettings, integrationTestSettings}
 import uk.gov.hmrc.SbtAutoBuildPlugin
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin._
@@ -17,21 +17,27 @@ lazy val scoverageSettings = {
 
 lazy val compile = Seq(
   ws,
-  "uk.gov.hmrc" %% "bootstrap-backend-play-27" % "5.3.0"
+  "uk.gov.hmrc" %% "bootstrap-backend-play-28" % "5.3.0"
 )
 
+val it = "it"
+
 lazy val test = Seq(
-  "uk.gov.hmrc" %% "hmrctest" % "3.10.0-play-26" % "test",
-  "org.scalatest" %% "scalatest" % "3.0.8" % "test",
-  "com.typesafe.play" %% "play-test" % PlayVersion.current % "test",
-  "org.mockito" % "mockito-all" % "2.0.2-beta" % "test"
+  "uk.gov.hmrc"            %% "bootstrap-test-play-28" % "5.3.0"   % Test,
+  "org.scalatest"          %% "scalatest"              % "3.2.9"   % Test,
+  "com.typesafe.play"      %% "play-test"              % current   % Test,
+  "org.scalatestplus.play" %% "scalatestplus-play"     % "5.1.0"   % Test,
+  "org.scalatestplus"      %% "mockito-1-10"           % "3.1.0.0" % Test,
+  "com.vladsch.flexmark"    % "flexmark-all"           % "0.35.10" % Test
 )
 
 lazy val itTest = Seq(
-  "uk.gov.hmrc" %% "hmrctest" % "3.10.0-play-26" % "it",
-  "org.scalatest" %% "scalatest" % "3.0.8" % "it",
-  "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % "it",
-  "com.github.tomakehurst" % "wiremock-jre8" % "2.21.0" % "it"
+  "uk.gov.hmrc"             %% "bootstrap-test-play-28" % "5.3.0"   % it,
+  "org.scalatest"           %% "scalatest"              % "3.2.9"   % it,
+  "com.typesafe.play"       %% "play-test"              % current   % it,
+  "org.scalatestplus.play"  %% "scalatestplus-play"     % "5.1.0"   % it,
+  "com.github.tomakehurst"  %  "wiremock-standalone"    % "2.27.1"  % it,
+  "com.vladsch.flexmark"    % "flexmark-all"            % "0.35.10" % it
 )
 
 lazy val appName: String = "nrs-retrieval"

--- a/build.sbt
+++ b/build.sbt
@@ -17,8 +17,7 @@ lazy val scoverageSettings = {
 
 lazy val compile = Seq(
   ws,
-  "uk.gov.hmrc" %% "bootstrap-backend-play-27" % "5.3.0",
-  "uk.gov.hmrc" %% "simple-reactivemongo" % "8.0.0-play-27"
+  "uk.gov.hmrc" %% "bootstrap-backend-play-27" % "5.3.0"
 )
 
 lazy val test = Seq(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -44,8 +44,6 @@ play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.http.JsonErrorHandler"
 # ~~~~
 # Additional play modules can be added here
 
-play.modules.enabled += "play.modules.reactivemongo.ReactiveMongoHmrcModule"
-
 # Session Timeout
 # ~~~~
 # The default session timeout for the app is 15 minutes (900seconds).
@@ -147,11 +145,6 @@ auditing {
     }
   }
 }
-
-mongodb {
-  uri = "mongodb://localhost:27017/nrs-retrieval"
-}
-
 
 microservice {
   metrics {

--- a/it/uk/gov/hmrc/nrs/retrieval/NrsRetrievalIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/nrs/retrieval/NrsRetrievalIntegrationSpec.scala
@@ -3,15 +3,17 @@ package uk.gov.hmrc.nrs.retrieval
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.client.{MappingBuilder, WireMock}
 import com.github.tomakehurst.wiremock.matching.EqualToPattern
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.WSClient
 
 class NrsRetrievalIntegrationSpec
-  extends WordSpecLike
+  extends AnyWordSpec
     with Matchers
     with ScalaFutures
     with GuiceOneServerPerSuite
@@ -21,8 +23,6 @@ class NrsRetrievalIntegrationSpec
   private val xApiKeyHeader = "X-API-Key"
   private val xApiKey = "xApiKey"
   private val equalsXApiKey = new EqualToPattern(xApiKey)
-
-  override lazy val port: Int = 19391
 
   private lazy val local = s"http://localhost:$port"
   private lazy val serviceRoot = s"$local/nrs-retrieval"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,8 @@ resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.0.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.16.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "2.0.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.9")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.7")
 addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.6.1")
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.16")

--- a/test/uk/gov/hmrc/nrs/retrieval/UnitSpec.scala
+++ b/test/uk/gov/hmrc/nrs/retrieval/UnitSpec.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nrs.retrieval
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.http.Status
+
+trait UnitSpec extends AnyWordSpec with Matchers with Status with MockitoSugar

--- a/test/uk/gov/hmrc/nrs/retrieval/connectors/NonrepRetrievalConnectorSpec.scala
+++ b/test/uk/gov/hmrc/nrs/retrieval/connectors/NonrepRetrievalConnectorSpec.scala
@@ -17,24 +17,22 @@
 package uk.gov.hmrc.nrs.retrieval.connectors
 
 import com.google.inject.{AbstractModule, Guice, Injector}
-import org.mockito.Matchers.{any, contains}
+import org.mockito.Matchers._
 import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
 import play.api.Environment
 import play.api.libs.ws.WSClient
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.nrs.retrieval.UnitSpec
 import uk.gov.hmrc.nrs.retrieval.config.{AppConfig, WSHttpT}
-import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
-class NonrepRetrievalConnectorSpec extends UnitSpec with MockitoSugar {
+class NonrepRetrievalConnectorSpec extends UnitSpec {
   private val mockWsHttp = mock[WSHttpT]
   private val mockEnvironment = mock[Environment]
   private val mockAppConfig = mock[AppConfig]
   private val mockWSClient = mock[WSClient]
-
   private val mockHttpResponse = mock[HttpResponse]
 
   implicit val mockHeaderCarrier: HeaderCarrier = mock[HeaderCarrier]
@@ -56,12 +54,13 @@ class NonrepRetrievalConnectorSpec extends UnitSpec with MockitoSugar {
   private val connector: NonrepRetrievalConnector = injector.getInstance(classOf[NonrepRetrievalConnector])
 
   "search" should {
-     "make a call to /submission-metadata" in {
+    "make a call to /submission-metadata" in {
       val httpResponseBody: String = "someResponse"
       when(mockHttpResponse.body).thenReturn(httpResponseBody)
-      when(mockHttpResponse.status).thenReturn(200)
+      when(mockHttpResponse.status).thenReturn(OK)
       when(mockHttpResponse.headers).thenReturn(Map("headerOne" -> Seq("valOne", "valTwo")))
-      when(mockWsHttp.GET[HttpResponse](contains("submission-metadata"), any(), any())(any(), any(), any())).thenReturn(Future.successful(mockHttpResponse))
+      when(mockWsHttp.GET[HttpResponse](contains("submission-metadata"), any(), any())(any(), any(), any()))
+        .thenReturn(Future.successful(mockHttpResponse))
 
       connector.search(Seq(("someParameter", "someValue"))).map { response =>
         response.body shouldBe httpResponseBody
@@ -73,9 +72,10 @@ class NonrepRetrievalConnectorSpec extends UnitSpec with MockitoSugar {
     "make a call to /submission-bundles/:vaultId/:archiveId/retrieval-requests" in {
       val httpResponseBody: String = "someResponse"
       when(mockHttpResponse.body).thenReturn(httpResponseBody)
-      when(mockHttpResponse.status).thenReturn(202)
+      when(mockHttpResponse.status).thenReturn(ACCEPTED)
       when(mockHttpResponse.headers).thenReturn(Map("headerOne" -> Seq("valOne", "valTwo")))
-      when(mockWsHttp.POST[Any, Any](contains("submission-bundles"), any(), any())(any(), any(), any(), any())).thenReturn(Future.successful(mockHttpResponse))
+      when(mockWsHttp.POST[Any, Any](contains("submission-bundles"), any(), any())(any(), any(), any(), any()))
+        .thenReturn(Future.successful(mockHttpResponse))
 
       connector.submitRetrievalRequest(testVaultId, testArchiveId).map { response =>
         response.status shouldBe 202
@@ -87,7 +87,7 @@ class NonrepRetrievalConnectorSpec extends UnitSpec with MockitoSugar {
     "make a call to /submission-bundles/$vaultId/$archiveId" in {
       val httpResponseBody: String = "someResponse"
       when(mockHttpResponse.body).thenReturn(httpResponseBody)
-      when(mockHttpResponse.status).thenReturn(200)
+      when(mockHttpResponse.status).thenReturn(OK)
       when(mockHttpResponse.headers).thenReturn(Map("headerOne" -> Seq("valOne", "valTwo")))
       when(mockHeaderCarrier.headers(any())).thenReturn(Seq.empty)
       when(mockHeaderCarrier.extraHeaders).thenReturn(Seq.empty)

--- a/test/uk/gov/hmrc/nrs/retrieval/controllers/NonrepRetrievalControllerControllerSpec.scala
+++ b/test/uk/gov/hmrc/nrs/retrieval/controllers/NonrepRetrievalControllerControllerSpec.scala
@@ -16,32 +16,32 @@
 
 package uk.gov.hmrc.nrs.retrieval.controllers
 
-import org.mockito.Matchers.any
+import org.mockito.Matchers._
 import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.http.Status
 import play.api.libs.ws.WSResponse
-import play.api.test.{FakeRequest, StubControllerComponentsFactory}
+import play.api.test.Helpers.defaultAwaitTimeout
+import play.api.test.{FakeRequest, Helpers, StubControllerComponentsFactory}
 import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.nrs.retrieval.UnitSpec
 import uk.gov.hmrc.nrs.retrieval.connectors.NonrepRetrievalConnector
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class NonrepRetrievalControllerControllerSpec extends UnitSpec with WithFakeApplication with MockitoSugar with StubControllerComponentsFactory {
+class NonrepRetrievalControllerControllerSpec extends UnitSpec with GuiceOneServerPerSuite with StubControllerComponentsFactory {
 
   private val fakeRequest = FakeRequest("GET", "/")
-
   private val httpResponseBody = "someResponse"
-  private val mockHttpResponse = mock[HttpResponse]
-  when(mockHttpResponse.body).thenReturn(httpResponseBody)
-  when(mockHttpResponse.status).thenReturn(Status.OK)
-  when(mockHttpResponse.headers).thenReturn(Map.empty[String,Seq[String]])
 
   private val mockWSResponse = mock[WSResponse]
-
   private val mocKConnector = mock[NonrepRetrievalConnector]
+  private val mockHttpResponse = mock[HttpResponse]
+
+  when(mockHttpResponse.body).thenReturn(httpResponseBody)
+  when(mockHttpResponse.status).thenReturn(Status.OK)
+  when(mockHttpResponse.headers).thenReturn(Map.empty[String, Seq[String]])
   when(mocKConnector.search(any())(any())).thenReturn(Future.successful(mockHttpResponse))
   when(mocKConnector.submitRetrievalRequest(any(), any())(any())).thenReturn(Future.successful(mockHttpResponse))
   when(mocKConnector.getSubmissionBundle(any(), any())(any())).thenReturn(Future.successful(mockWSResponse))
@@ -52,21 +52,21 @@ class NonrepRetrievalControllerControllerSpec extends UnitSpec with WithFakeAppl
   "search" should {
     "pass-through the search response" in {
       val result = controller.search()(fakeRequest)
-      status(result) shouldBe Status.OK
+      Helpers.status(result) shouldBe OK
     }
   }
 
   "submitRetrievalRequest" should {
     "pass-through the search response" in {
       val result = controller.submitRetrievalRequest("1", "2")(fakeRequest)
-      status(result) shouldBe Status.OK
+      Helpers.status(result) shouldBe OK
     }
   }
 
   "statusSubmissionBundle" should {
     "pass-through the search response" in {
       val result = controller.statusSubmissionBundle("1", "2")(fakeRequest)
-      status(result) shouldBe Status.OK
+      Helpers.status(result) shouldBe OK
     }
   }
 
@@ -74,12 +74,11 @@ class NonrepRetrievalControllerControllerSpec extends UnitSpec with WithFakeAppl
     val header = "X-API-Key" -> "aValidKey"
 
     "create a header carrier with an X-API-Key header if one exists in the request" in {
-      controller.headerCarrier(fakeRequest.withHeaders(header)).extraHeaders should contain (header)
+      controller.headerCarrier(fakeRequest.withHeaders(header)).extraHeaders should contain(header)
     }
 
     "create an empty header carrier if no X-API-Key header exists in the request" in {
       controller.headerCarrier(fakeRequest).extraHeaders.contains(header) shouldBe false
     }
   }
-
 }

--- a/test/uk/gov/hmrc/nrs/retrieval/controllers/NonrepRetrievalControllerControllerSpec.scala
+++ b/test/uk/gov/hmrc/nrs/retrieval/controllers/NonrepRetrievalControllerControllerSpec.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.nrs.retrieval.controllers
 
 import org.mockito.Matchers._
 import org.mockito.Mockito.when
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.http.Status
 import play.api.libs.ws.WSResponse
 import play.api.test.Helpers.defaultAwaitTimeout
@@ -30,8 +29,7 @@ import uk.gov.hmrc.nrs.retrieval.connectors.NonrepRetrievalConnector
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class NonrepRetrievalControllerControllerSpec extends UnitSpec with GuiceOneServerPerSuite with StubControllerComponentsFactory {
-
+class NonrepRetrievalControllerControllerSpec extends UnitSpec with StubControllerComponentsFactory {
   private val fakeRequest = FakeRequest("GET", "/")
   private val httpResponseBody = "someResponse"
 


### PR DESCRIPTION
Second pr for NONPR-1718 which removes the unused `mongo` dependencies.