### PR TITLE
[NONPR-2134] error for unexpected status code for get submisison bundle

### DIFF
--- a/app/uk/gov/hmrc/nrs/retrieval/controllers/NonrepRetrievalController.scala
+++ b/app/uk/gov/hmrc/nrs/retrieval/controllers/NonrepRetrievalController.scala
@@ -19,61 +19,70 @@ package uk.gov.hmrc.nrs.retrieval.controllers
 import javax.inject.Singleton
 import com.google.inject.Inject
 import play.api.mvc._
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.http.{BadGatewayException, HeaderCarrier, HttpResponse, InternalServerException, NotFoundException}
 import uk.gov.hmrc.nrs.retrieval.connectors.NonrepRetrievalConnector
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import scala.concurrent.ExecutionContext
 
 @Singleton()
-class NonrepRetrievalController @Inject()(val nonrepRetrievalConnector: NonrepRetrievalConnector,
-                                          override val controllerComponents: ControllerComponents)
-                                         (implicit ec: ExecutionContext)
-  extends BackendController(controllerComponents) {
+class NonrepRetrievalController @Inject()(
+  val nonrepRetrievalConnector: NonrepRetrievalConnector,
+  override val controllerComponents: ControllerComponents)(implicit ec: ExecutionContext)
+    extends BackendController(controllerComponents) {
 
-   def search() = Action.async { implicit request =>
+  val search: Action[AnyContent] = Action.async { implicit request =>
     nonrepRetrievalConnector.search(mapToSeq(request.queryString)).map(response => Ok(response.body))
   }
 
-  def submitRetrievalRequest(vaultId: String, archiveId: String) = Action.async { implicit request =>
+  def submitRetrievalRequest(vaultId: String, archiveId: String): Action[AnyContent] = Action.async { implicit request =>
     nonrepRetrievalConnector.submitRetrievalRequest(vaultId, archiveId).map(response => rewriteResponse(response))
   }
 
-  def statusSubmissionBundle(vaultId: String, archiveId: String) = Action.async { implicit request =>
+  def statusSubmissionBundle(vaultId: String, archiveId: String): Action[AnyContent] = Action.async { implicit request =>
     nonrepRetrievalConnector.statusSubmissionBundle(vaultId, archiveId).map(response => rewriteResponse(response))
   }
 
-  def getSubmissionBundle(vaultId: String, archiveId: String) = Action.async { implicit request =>
-    nonrepRetrievalConnector.getSubmissionBundle(vaultId, archiveId)
-      .map{response => Ok(response.bodyAsBytes).withHeaders(mapToSeq(response.headers):_*)}
-  }
+  def getSubmissionBundle(vaultId: String, archiveId: String): Action[AnyContent] = Action.async { implicit request =>
+    nonrepRetrievalConnector.getSubmissionBundle(vaultId, archiveId).map { response =>
+      val errorMessage =
+        s"get submission bundle for vaultId: [$vaultId] archiveId: [$archiveId] received unexpected response status: ${response.status.toString}"
 
-  private def rewriteResponse (response: HttpResponse) = {
-    val headers: Seq[(String, String)] = mapToSeq(response.headers)
-    response.status match {
-      case 200 => Ok(response.body).withHeaders(headers:_*)
-      case 202 => Accepted(response.body).withHeaders(headers:_*)
-      case 404 => NotFound(response.body)
-      case _ => Ok(response.body)
+      response.status match {
+        case NOT_FOUND                                 => throw new NotFoundException(errorMessage)
+        case status if status >= INTERNAL_SERVER_ERROR => throw new BadGatewayException(errorMessage)
+        case status if status >= MULTIPLE_CHOICES      => throw new InternalServerException(errorMessage)
+        case _                                         => Ok(response.bodyAsBytes).withHeaders(mapToSeq(response.headers): _*)
+      }
     }
   }
 
-  def submissionPing = Action.async { implicit request =>
+  private def rewriteResponse(response: HttpResponse) = {
+    val headers: Seq[(String, String)] = mapToSeq(response.headers)
+    response.status match {
+      case OK        => Ok(response.body).withHeaders(headers: _*)
+      case ACCEPTED  => Accepted(response.body).withHeaders(headers: _*)
+      case NOT_FOUND => NotFound(response.body)
+      case _         => Ok(response.body)
+    }
+  }
+
+  val submissionPing: Action[AnyContent] = Action.async { implicit request =>
     nonrepRetrievalConnector.submissionPing().map(response => Ok(response.body))
   }
 
-  def retrievalPing = Action.async { implicit request =>
+  val retrievalPing: Action[AnyContent] = Action.async { implicit request =>
     nonrepRetrievalConnector.retrievalPing().map(response => Ok(response.body))
   }
 
   private def mapToSeq(sourceMap: Map[String, Seq[String]]): Seq[(String, String)] =
     sourceMap.keys.flatMap(k => sourceMap(k).map(v => (k, v))).toSeq
 
-  implicit def headerCarrier (implicit request: Request[AnyContent]): HeaderCarrier = {
+  implicit def headerCarrier(implicit request: Request[AnyContent]): HeaderCarrier = {
     val xApiKey = "X-API-Key"
     request.headers.get(xApiKey) match {
       case Some(xApiKeyValue) => HeaderCarrier().withExtraHeaders(xApiKey -> xApiKeyValue)
-      case _ => HeaderCarrier()
+      case _                  => HeaderCarrier()
     }
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -38,7 +38,7 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.MicroserviceModule"
 play.http.filters = "uk.gov.hmrc.play.bootstrap.filters.MicroserviceFilters"
 
 # Json error handler
-play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.http.JsonErrorHandler"
+play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.backend.http.JsonErrorHandler"
 
 # Play Modules
 # ~~~~

--- a/it/uk/gov/hmrc/nrs/retrieval/NrsRetrievalIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/nrs/retrieval/NrsRetrievalIntegrationSpec.scala
@@ -223,17 +223,17 @@ class NrsRetrievalIntegrationSpec
     val requestWithHeader = wsClientWithXApiKeyHeader(url)
     val retrievalPath = "/retrieval/submission-bundles/vaultId/archiveId"
 
-    def givenSubmissionBundlesReturns(status: Int, withHeaders: Boolean): Unit =
+    def givenSubmissionBundlesReturns(status: Int, withHeaders: Boolean, body: String = "some bytes"): Unit =
       wireMockServer.addStubMapping(
         mappingBuilder(get(urlPathMatching(retrievalPath)), withHeaders)
-          .willReturn(aResponse().withStatus(status)).build())
+          .willReturn(aResponse().withStatus(status).withBody(body)).build())
 
     Seq(
       (requestWithHeader, true, "the X-API-Key header"),
       (requestWithoutHeaders, false, "no headers")
     ).foreach { case (request, withHeaders, headersLabel) =>
       "pass through the X-API-Key header if set and return OK" when {
-        Seq(OK, CREATED, ACCEPTED, BAD_REQUEST, UNAUTHORIZED, FORBIDDEN, NOT_FOUND, INTERNAL_SERVER_ERROR, BAD_GATEWAY).foreach { status =>
+        Seq(OK, CREATED, ACCEPTED).foreach { status =>
           s"the request has $headersLabel and the submission bundles request returns the status $status" in {
             givenSubmissionBundlesReturns(status, withHeaders)
             request.get().futureValue.status shouldBe OK
@@ -245,6 +245,34 @@ class NrsRetrievalIntegrationSpec
           givenRequestRedirects(get(urlPathMatching(retrievalPath)), withHeaders)
           request.get().futureValue.status shouldBe OK
           verify(1, getRequestedFor(urlEqualTo(retrievalPath)))
+        }
+      }
+
+      "pass through the X-API-Key header if set and return NOT_FOUND" when {
+        s"the request has $headersLabel and the submission bundles request returns NOT_FOUND" in {
+          givenSubmissionBundlesReturns(NOT_FOUND, withHeaders)
+          request.get().futureValue.status shouldBe NOT_FOUND
+          verify(1, getRequestedFor(urlEqualTo(retrievalPath)))
+        }
+      }
+
+      "pass through the X-API-Key header if set and return INTERNAL_SERVER_ERROR" when {
+        Seq(BAD_REQUEST, UNAUTHORIZED, FORBIDDEN).foreach { status =>
+          s"the request has $headersLabel and the submission bundles request returns the status $status" in {
+            givenSubmissionBundlesReturns(status, withHeaders)
+            request.get().futureValue.status shouldBe INTERNAL_SERVER_ERROR
+            verify(1, getRequestedFor(urlEqualTo(retrievalPath)))
+          }
+        }
+      }
+
+      "pass through the X-API-Key header if set and return BAD_GATEWAY" when {
+        Seq(INTERNAL_SERVER_ERROR, BAD_GATEWAY).foreach { status =>
+          s"the request has $headersLabel and the submission bundles request returns the status $status" in {
+            givenSubmissionBundlesReturns(status, withHeaders)
+            request.get().futureValue.status shouldBe BAD_GATEWAY
+            verify(1, getRequestedFor(urlEqualTo(retrievalPath)))
+          }
         }
       }
     }


### PR DESCRIPTION
NONPR-2134 is resolved when running locally but we still get 0 byte downloads when running against remote services, including the stub in dev and the real backend in QA. The cause is currently unknown. 

One difficulty with investigating this issue is that currently the `getSubmissionBundle` endpoint swallows any upstream exceptions and always returns `OK`.  Any issues are not logged in `kibana`. 

This was a known issue - see https://jira.tools.tax.service.gov.uk/browse/NONPR-2082 

This PR ensures that an appropriate error is thrown by `getSubmissionBundle` when an unexpected http status code is returned by the upstream system. The error will be caught and logged by the `ErrorHandler` and an MDTP-standard http status code will be returned to the consumer.

