### PR TITLE
[NONPR-2134] improve logging in download

### DIFF
--- a/app/uk/gov/hmrc/nrs/retrieval/controllers/NonrepRetrievalController.scala
+++ b/app/uk/gov/hmrc/nrs/retrieval/controllers/NonrepRetrievalController.scala
@@ -48,13 +48,17 @@ class NonrepRetrievalController @Inject()(
   def getSubmissionBundle(vaultId: String, archiveId: String): Action[AnyContent] = Action.async { implicit request =>
     val messagePrefix = s"get submission bundle for vaultId: [$vaultId] archiveId: [$archiveId]"
 
+    logger.info(messagePrefix)
+
     nonrepRetrievalConnector.getSubmissionBundle(vaultId, archiveId).map { response =>
-      val errorMessage = s"$messagePrefix received unexpected response status: ${response.status.toString}"
+      val message = s"$messagePrefix received response status: ${response.status.toString}"
+
+      logger.info(message)
 
       response.status match {
-        case NOT_FOUND                                 => throw new NotFoundException(errorMessage)
-        case status if status >= INTERNAL_SERVER_ERROR => throw new BadGatewayException(errorMessage)
-        case status if status >= MULTIPLE_CHOICES      => throw new InternalServerException(errorMessage)
+        case NOT_FOUND                                 => throw new NotFoundException(message)
+        case status if status >= INTERNAL_SERVER_ERROR => throw new BadGatewayException(message)
+        case status if status >= MULTIPLE_CHOICES      => throw new InternalServerException(message)
         case status =>
           // log response size rather than the content as this might contain sensitive information
           val bytes = response.bodyAsBytes


### PR DESCRIPTION
```
sbt test
...
[info] ScalaTest
[info] Run completed in 1 second, 719 milliseconds.
[info] Total number of tests run: 8
[info] Suites: completed 2, aborted 0
[info] Tests: succeeded 8, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 8, Failed 0, Errors 0, Passed 8
```


```
sbt it:test
...
[info] ScalaTest
[info] Run completed in 8 seconds, 797 milliseconds.
[info] Total number of tests run: 111
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 111, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```